### PR TITLE
Add hook for discarding an exception

### DIFF
--- a/BugsnagPlugin.php
+++ b/BugsnagPlugin.php
@@ -41,6 +41,13 @@ class BugsnagPlugin extends BasePlugin {
 
         Yii::app()->onException = function($exceptionEvent) use ($service)
         {
+
+            foreach (craft()->plugins->call('discardBugsnagExceptionEvent', array($exceptionEvent)) as $shouldDiscard) {
+                if ($shouldDiscard) {
+                    return;
+                }
+            }
+
             $service->logException($exceptionEvent->exception);
         };
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ capturing errors from your applications.
         'notify_release_stages' => ['production', 'staging']
     );
     ```
+
+## Hooks
+
+### discardBugsnagExceptionEvent($event)
+
+Give plugins a chance to discard certain types of exceptions, such as a 404.
+
+```
+/**
+ * Stop an exception event from being reported to bugsnag
+ * 
+ * @param CExeptionEvent $event
+ * @return boolean
+ */
+function discardBugsnagExceptionEvent($event)
+{
+	$exception = $event->exception;
+
+	if (/* $exception should be discarded */){
+		return true;
+	}
+}
+
+```
+
     
 ## Other
 


### PR DESCRIPTION
This allows unimportant exceptions to be discarded before they reach bugsnag.
