### PR TITLE
Filter out console application

### DIFF
--- a/services/BugsnagService.php
+++ b/services/BugsnagService.php
@@ -59,7 +59,7 @@ class BugsnagService extends BaseApplicationComponent
             $client->setProxySettings($config->get('proxy', 'bugsnag'));
         }
 
-        if (craft()->userSession->isLoggedIn()) {
+        if (!craft()->isConsole() && craft()->userSession->isLoggedIn()) {
             $user = craft()->userSession->getUser();
 
             $client->setUser([


### PR DESCRIPTION
Because Craft\ConsoleApp.session" is not defined in Craft 2.5+.
