### PR TITLE
Fix console exception

### DIFF
--- a/services/BugsnagService.php
+++ b/services/BugsnagService.php
@@ -59,7 +59,7 @@ class BugsnagService extends BaseApplicationComponent
             $client->setProxySettings($config->get('proxy', 'bugsnag'));
         }
 
-        if (craft()->userSession->isLoggedIn()) {
+        if (CRAFT_ENVIRONMENT !== 'console' && craft()->userSession->isLoggedIn()) {
             $user = craft()->userSession->getUser();
 
             $client->setUser([


### PR DESCRIPTION
When running in console, trying to access craft()->userSession throws an exception.  Avoid this by not trying to access this in console context.
